### PR TITLE
Fix broken links in troubleshooting section

### DIFF
--- a/articles/troubleshooting.md
+++ b/articles/troubleshooting.md
@@ -23,9 +23,9 @@ You can use [Cascading Traps](http://docs.cascading.org/cascading/2.0/userguide/
 Testing
 -------
 
-You may use the functions and macros from the [cascalog.testing](https://github.com/nathanmarz/cascalog/blob/develop/src/clj/cascalog/testing.clj) namespace together with clojure.test test your queries. See [Cascalog's own tests](https://github.com/nathanmarz/cascalog/tree/develop/test/cascalog) for examples.
+You may use the functions and macros from the [midje.cascalog](https://github.com/nathanmarz/cascalog/blob/develop/midje-cascalog/src/midje/cascalog.clj) namespace together with clojure.test test your queries. See [Cascalog's own tests](https://github.com/nathanmarz/cascalog/tree/develop/cascalog-core/test/cascalog) for examples.
 
- It uses for example `fact?-` to execute a query and compare its outputs with the expected ones or something like `(facts query => (produces [[3 10] [1 5] [5 11]])` where `(def query (<- ...))`. Read Sam Ritchie's blog post [Cascalog Testing 2.0 ](http://sritchie.github.com/2012/01/22/cascalog-testing-20.html) for more details and examples of midje-cascalog 0.4.0.
+It uses for example `fact?-` to execute a query and compare its outputs with the expected ones or something like `(facts query => (produces [[3 10] [1 5] [5 11]])` where `(def query (<- ...))`. Read Sam Ritchie's blog post [Cascalog Testing 2.0 ](http://sritchie.github.io/2012/01/22/cascalog-testing-20/) for more details and examples of midje-cascalog 0.4.0.
 
 Live coding
 -----------


### PR DESCRIPTION
- The link to the non-existent `cascalog.testing` namespace was changed
  to midje.cascalog and now points to the midje.cascalog directory in
  the cascalog repo.
- The link to Cascalog's own tests now points to the
  cascalog-core/test/cascalog directory within the cascalog repo.
- The link to Sam Ritchie's Cascalog Testing 2.0 post was corrected. Was
  previously returning 404.
